### PR TITLE
[AIPs] Ensure each AIP has the title as the first section header.

### DIFF
--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -1,6 +1,6 @@
 ---
 aip: (this is determined by the AIP Manager)
-title:
+title: (AIP title)
 author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s). Details are below.>
 discussions-to (*optional): <a url pointing to the official discussion thread>
 Status: <Draft | Last Call | Accepted | Final | Rejected>
@@ -10,6 +10,8 @@ created:
 updated (*optional):
 requires (*optional): <AIP number(s)>
 ---
+
+# AIP-(AIP number or TBD) - (AIP title)
 
 ## Summary
 

--- a/aips/aip-1.md
+++ b/aips/aip-1.md
@@ -9,6 +9,8 @@ type: Standard (Core)
 created: 12/7/2022
 ---
 
+# AIP-1 - Proposer selection improvements
+
 ## Summary
 
 This change brings two simple improvements to proposer selection:

--- a/aips/aip-2.md
+++ b/aips/aip-2.md
@@ -9,6 +9,8 @@ type: Standard (framework)
 created: 12/7/2022
 ---
 
+# AIP-2 - Multiple Token Changes
+
 ## Summary
 
 This proposal contains the following changes:

--- a/aips/aip-3.md
+++ b/aips/aip-3.md
@@ -9,6 +9,8 @@ type: Standard (framework)
 created: 12/7/2022
 ---
 
+# AIP-3 - Multi-step Governance Proposal
+
 ## Summary
 
 The Aptos on-chain governance is a process by which the Aptos community can govern operations and development of the Aptos blockchain via proposing, voting on, and resolving proposals.

--- a/aips/aip-4.md
+++ b/aips/aip-4.md
@@ -8,6 +8,9 @@ last-call-end-date (*optional):
 type: Standard (framework)
 created: 12/8/2022
 ---
+
+# AIP-4 - Update Simple Map To Save Gas
+
 ## Summary
 
 Change the internal implementation of SimpleMap in order to reduce gas prices with minimal impact on Move and Public APIs.

--- a/aips/aip-6.md
+++ b/aips/aip-6.md
@@ -9,6 +9,8 @@ type: Standard (framework)
 created: 12/16/2022
 ---
 
+# AIP-6 - Delegation pool for node operators
+
 ## Summary
 
 Currently, only token owners with 1M APT are able to stake their tokens and earn staking rewards. We want to enable everyone in the community to have access to staking rewards as well. We propose adding a delegation contract to the framework. This extension enables multiple token owners to contribute any amount of APT to the same permissionless delegation pool. As long as the total amount of APT in a delegation pool meets the minimum stake required for staking, the validator node on which it is set on will be able to join the active set and earn staking rewards.

--- a/aips/aip-7.md
+++ b/aips/aip-7.md
@@ -1,5 +1,5 @@
 ---
-aip: 8
+aip: 7
 title: Transaction fee distribution
 author: georgemitenkov
 discussions-to: https://github.com/aptos-foundation/AIPs/issues/23
@@ -8,6 +8,9 @@ last-call-end-date (*optional):
 type: Standard (framework)
 created: 12/20/2022
 ---
+
+# AIP-7 - Transaction fee distribution
+
 ## Summary
 
 Currently, all transaction fees are burnt on Aptos. This design choice does not motivate validators to prioritise the highest value transactions, as well as use bigger blocks of transactions, leading to lower throughput of the system. For example, a validator can submit an empty block and still get rewarded. We would like to solve this issue by distributing transaction fees to validators. In particular, we want to collect transaction fees for each block, store them, and then redistribute at the end of each epoch.

--- a/aips/higher-order-functions.md
+++ b/aips/higher-order-functions.md
@@ -10,6 +10,8 @@ created: 2023/1/9
 updated: 2023/1/9
 ---
 
+# AIP-TBD - Higher-Order Inline Functions for Collections
+
 ## Summary
 
 Recently, the concept of *inline functions* has been added to Aptos Move. Those functions are expanded at compile time and do not have an equivalent in the Move bytecode. This ability allows them to implement a feature which is currently not available for regular Move functions: taking functions, given as lambda expressions, as parameters. Given this, we can define popular higher-order functions like 'for_each', 'filter', 'map', and 'fold' for collection types in Move. In this AIP, we suggest a set of conventions for those functions. 

--- a/aips/objects.md
+++ b/aips/objects.md
@@ -11,6 +11,8 @@ updated: N/A
 requires: AIP_number_of(Resource Groups)
 ---
 
+# AIP-TBD - Move Objects
+
 ## Summary
 
 This AIP proposes Move objects for global access to composite set of resources stored at a single address on-chain. By leveraging the account model, objects can directly emit events that can lead to richer understanding of on-chain actions. Finally, objects offer a rich capability model that allows for fine-grained resource control and ownership objects in a single store.

--- a/aips/resource_groups.md
+++ b/aips/resource_groups.md
@@ -11,6 +11,8 @@ updated: N/A
 requires: N/A
 ---
 
+# AIP-TBD - Resource Groups
+
 ## Summary
 
 This AIP proposes resource groups to support storing multiple distinct Move resources together into a single storage slot.

--- a/aips/token_objects.md
+++ b/aips/token_objects.md
@@ -11,6 +11,8 @@ updated:
 requires: AIP_number_of(Move Objects)
 ---
 
+# AIP-TBD - Tokens as Objects
+
 ## Summary
 
 This AIP proposes a new Token standard using Move Objects. In this model, a token only represents the base concept of a token and is used as a building blocker for applications of tokens, such as NFTs, game assets, no code solutions, etc.


### PR DESCRIPTION
This PR ensures that all AIPs have the AIP number and title as the first section header. This makes it much easier to immediately identify which AIP you're looking at. It also adds the title requirements to the template and fixes a small typo where AIP-7 was marked as 8 in the doc.