### PR TITLE
AIP draft: New cryptography natives for hashing and MultiEd25519 PK validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Aptos Improvement Proposals (AIP) describe standards for the Aptos Network including the core blockchain protocol and the development platform (Move), smart contracts and systems for smart contract verification, standards for the deployment and operation of the Aptos Network, APIs for accessing the Aptos Network and processing information from the Aptos Network.
 
+## How to submit an AIP
+
+ 1. Fork this repo into your own GitHub
+ 2. Copy `TEMPLATE.md` into your new AIP file in `aips/<your-feature-name-NO-AIP-#-here>.md`
+    + Name your AIP file based on your feature, not the AIP number, which will be picked for your later.
+    + e.g., `new-zero-knowledge-range-proof-verifiers.md` is a good name.
+    - ...but `aip-14.md` or `14.md` is **NOT** a good name.
+ 3. Edit your AIP file
+    - Fill in the YAML header (see instructions there)
+    - Follow the template guidelines to the best of your ability
+ 4. Commit these changes to your repo
+ 5. Submit a pull request on GitHub to this repo.
+
 ## AIP Overview
 
 This table contains an overview of all created and tracked AIPs. It should be updated with each new AIP.

--- a/aips/aip-14.md
+++ b/aips/aip-14.md
@@ -15,36 +15,89 @@ requires (*optional):
 
 ## Summary
 
-Include a brief description summarizing the intended change. This should be no more than a couple of sentences.
+This is a bundle of 3 intended changes:
+
+ - add support for computing the [Blake2b-256 hash function](https://github.com/aptos-labs/aptos-core/pull/5436) in Move smart contracts
+ - add support for computing [SHA2-512, SHA3-512 and RIPEMD-160 hash functions](https://github.com/aptos-labs/aptos-core/pull/4181) in Move smart contracts
+ - upgraded [MultiEd25519 PK validation](https://github.com/aptos-labs/aptos-core/pull/5822) to V2 address a bug where a PK with 0 sub-PKs would've been considered valid by our 
+   - deprecates `0x1::multi_ed25519::public_key_validate` API
+   - deprecates `0x1::multi_ed25519::new_validated_public_key_from_bytes` API
+   - introduces `0x1::multi_ed25519::public_key_validate_v2` API
+   - introduces `0x1::multi_ed25519::new_validated_public_key_from_bytes_v2` API
+
 
 ## Motivation
 
-Describe the impetus for this change. What does it accomplish? What might occur if we do not accept this proposal?
+### Hashing
+
+Support for the new hash functions will be useful when building bridges to other chains.
+For example, computing Bitcoin addresses requires evaluating a RIPEMD-160 hash (see [here](https://en.bitcoin.it/wiki/Protocol_documentation#Addresses)).
+If we do not accept this proposal, building bridges to other chains (as well other cryptographic applications) will be costly gas-wise, as per conversations with companies like Composable.Finance.
+
+### MultiEd25519 V2 PK validation
+
+The PK validation bug would've broken the type safety of our `0x1::multi_ed25519::ValidatedPublicKey` struct type, which is supposed to guaranteed that a PK is well-formed which among, other things, requires that the # of sub-PKs be greater than 0.
+
+While such ill-formed `0x1::multi_ed25519::ValidatedPublicKey` structs would have **NOT** created any security issues during multisignature verification, since they are easily dismissed when used to verify a signature (i.e., via `0x1::multi_ed25519::signature_verify_strict`), they would have forced developers to think about the consequences of using such ill-formed PKs throughout their Move modules, increasing cognitive overload. 
+
+If we do not accept this proposal, it could be possible for users to mis-use `0x1::multi_ed25519::ValidatedPublicKey` structs and create other security issues. 
+For example, the non-repudiation property of a signature could be broken as follows.
+Consider a contract that (1) manually de-serializes such a struct, (2) parses all the sub-PKs, (re)implements its own signature validation logic to check:
+
+```
+// Constructs an ill-formed n-out-of-n PK from evil bytes
+let ill_formed_validated_pk = multi_ed25519::new_validated_public_key_from_bytes(evil_bytes);
+
+let sub_sigs = vector<vector<u8>> = /* some signatures */;
+
+// Deserializes such a PK, implicitly assuming the # of sub-PKs to be greater than 0.
+let sub_pks : vec<vector<u8>> = deserialize_multi_ed25519_pk(ill_formed_validated_pk);
+
+for i in 0..sub_pks.len() {
+	if !verify_sub_sig(sub_sigs[i], sub_pks[i]) {
+		return false;
+	}
+}
+
+return true;
+```
+
+Note that, for any ill-formed PK with 0 sub PKs, any multisignature would pass this verification, which implies a loss of non-repudiation.
+
+Although this example is far-fetched (since developers will likely rely on `0x1::multi_ed25519::signature_verify_strict`, which will reject the PK and thus any signature), it highlights the importance of maintaining the type safety of the struct so as to guarantee something meaningful to users about its de-serialized format.
 
 ## Rationale
 
-Explain why you submitted this proposal specifically over alternative solutions. Why is this the best possible outcome?
+**Q:** Explain why you submitted this proposal specifically over alternative solutions. Why is this the best possible outcome?
+
+**A:** The hash functions just adds new functionality, so no alternatives were considered. The MultiEd25519 change is a bugfix. The alternative would have been not to fix it which, as argued above, is not ideal.
 
 ## Specification
 
-Describe in detail precisely how this proposal should be implemented. Include proposed design principles that should be followed in implementing this feature. Make the proposal specific enough to allow others to build upon it and perhaps even derive competing implementations.
+The hash function and MultiEd25519 APIs are properly documented as part of the reference implementation below.
 
 ## Reference Implementation
 
-This is an optional yet highly encouraged section where you may include an example of what you are seeking in this proposal. This can be in the form of code, diagrams, or even plain text. IDeally, we have a link to a living repository of code exemplifying the standard, or, for simpler cases, inline code.
+ - [Blake2b-256 hash function](https://github.com/aptos-labs/aptos-core/pull/5436)
+ - [SHA2-512, SHA3-512 and RIPEMD-160 hash functions](https://github.com/aptos-labs/aptos-core/pull/4181)
+ - [MultiEd25519 PK validation V2](https://github.com/aptos-labs/aptos-core/pull/5822)
 
 ## Risks and Drawbacks
 
-Express here the potential negative ramifications of taking on this proposal. What are the hazards?
+- The lack of a `#[deprecated]` or `#[deprecated_by=new_func_name]` annotation in Move makes it difficult to easily warn the users about using the outdated MultiEd25519 PK validation APIs. i.e.,:
+  - the deprecated `0x1::multi_ed25519::public_key_validate` API
+  - the deprecated `0x1::multi_ed25519::new_validated_public_key_from_bytes` API
+
+- This means users could still call these APIs and accidentally find ways of mis-using the ill-formed PKs.
 
 ## Future Potential
 
-Think through the evolution of this proposal well into the future. How do you see this playing out? What would this proposal result in in one year? In five years?
+The hash functions could be used for many cryptographic applications on chains (e.g., verifying zk-STARK proofs).
 
 ## Suggested implementation timeline
 
-When should community expect to see it on devnet
+When should community expect to see it on devnet? I don’t know how to find out the answer.
 
-testnet?
+Testnet? I don’t know how to find out the answer.
 
-On mainnet?
+On mainnet? I don’t know how to find out the answer.

--- a/aips/aip-14.md
+++ b/aips/aip-14.md
@@ -1,0 +1,50 @@
+---
+aip: 14 
+title: New cryptography natives for hashing and MultiEd25519 PK validation
+author: Alin Tomescu <alin@aptoslabs.com>
+discussions-to (*optional): https://github.com/aptos-foundation/AIPs/issues/57
+Status: Draft # | Last Call | Accepted | Final | Rejected
+last-call-end-date (*optional):
+type: Standard Framework # <Standard (Core, Networking, Interface, Application, Framework) | Informational | Process>
+created: 2022-02-02
+updated (*optional):
+requires (*optional):
+---
+
+# AIP-14 - New cryptography natives for hashing and MultiEd25519 PK validation
+
+## Summary
+
+Include a brief description summarizing the intended change. This should be no more than a couple of sentences.
+
+## Motivation
+
+Describe the impetus for this change. What does it accomplish? What might occur if we do not accept this proposal?
+
+## Rationale
+
+Explain why you submitted this proposal specifically over alternative solutions. Why is this the best possible outcome?
+
+## Specification
+
+Describe in detail precisely how this proposal should be implemented. Include proposed design principles that should be followed in implementing this feature. Make the proposal specific enough to allow others to build upon it and perhaps even derive competing implementations.
+
+## Reference Implementation
+
+This is an optional yet highly encouraged section where you may include an example of what you are seeking in this proposal. This can be in the form of code, diagrams, or even plain text. IDeally, we have a link to a living repository of code exemplifying the standard, or, for simpler cases, inline code.
+
+## Risks and Drawbacks
+
+Express here the potential negative ramifications of taking on this proposal. What are the hazards?
+
+## Future Potential
+
+Think through the evolution of this proposal well into the future. How do you see this playing out? What would this proposal result in in one year? In five years?
+
+## Suggested implementation timeline
+
+When should community expect to see it on devnet
+
+testnet?
+
+On mainnet?

--- a/aips/new-hash-functions-and-multi-ed25519-natives.md
+++ b/aips/new-hash-functions-and-multi-ed25519-natives.md
@@ -1,17 +1,17 @@
 ---
-aip: 14 
+aip: TBD
 title: New cryptography natives for hashing and MultiEd25519 PK validation
 author: Alin Tomescu <alin@aptoslabs.com>
 discussions-to (*optional): https://github.com/aptos-foundation/AIPs/issues/57
 Status: Draft # | Last Call | Accepted | Final | Rejected
 last-call-end-date (*optional):
 type: Standard Framework # <Standard (Core, Networking, Interface, Application, Framework) | Informational | Process>
-created: 2022-02-02
+created: 02/02/2022
 updated (*optional):
 requires (*optional):
 ---
 
-# AIP-14 - New cryptography natives for hashing and MultiEd25519 PK validation
+# AIP TBD - New cryptography natives for hashing and MultiEd25519 PK validation
 
 ## Summary
 


### PR DESCRIPTION
Also, updates `README.md` with instructions on how to submit an AIP.

Discussion will be held in this issue: https://github.com/aptos-foundation/AIPs/issues/57