### PR TITLE
replace 'implementation' with 'deployment'

### DIFF
--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -41,10 +41,14 @@ Express here the potential negative ramifications of taking on this proposal. Wh
 
 Think through the evolution of this proposal well into the future. How do you see this playing out? What would this proposal result in in one year? In five years?
 
+## Suggested implementation timeline
+
+Describe how long you expect the implementation effort to take, perhaps splitting it up into stages or milestones.
+
 ## Suggested deployment timeline
 
-When should community expect to see it on devnet
+When should community expect to see this deployed on devnet?
 
-testnet?
+On testnet?
 
 On mainnet?

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -41,7 +41,7 @@ Express here the potential negative ramifications of taking on this proposal. Wh
 
 Think through the evolution of this proposal well into the future. How do you see this playing out? What would this proposal result in in one year? In five years?
 
-## Suggested implementation timeline
+## Suggested deployment timeline
 
 When should community expect to see it on devnet
 


### PR DESCRIPTION
As far as I can tell, the text in the template is asking about a **deployment** timeline on devnet, testnet and mainnet, not an _implementation_ timeline.

If it's asking about both things, let's add separate sections.

If it's asking about implementation, then I think the guidelines are confusing: i.e., what does deployment on devnet, testnet and mainnet have to do with the _implementation_ timeline?