### PR TITLE
update timeline in AIP

### DIFF
--- a/aips/new-hash-functions-and-multi-ed25519-natives.md
+++ b/aips/new-hash-functions-and-multi-ed25519-natives.md
@@ -96,8 +96,8 @@ The hash functions could be used for many cryptographic applications on chains (
 
 ## Suggested implementation timeline
 
-When should community expect to see it on devnet? I don’t know how to find out the answer.
+Everything has already been implemented.
 
-Testnet? I don’t know how to find out the answer.
+## Suggested deployment timeline
 
-On mainnet? I don’t know how to find out the answer.
+This would likely make it to testnet early March.


### PR DESCRIPTION
Updated timeline for https://github.com/aptos-foundation/AIPs/pull/59, as advised by @movekevin.

Tagging @michelle-aptos, @sherry-x and @davidiw for review (since I seem unable to manually add reviewers)