### PR TITLE
fix: typo at LinearTransferRef aip10

### DIFF
--- a/aips/aip-10.md
+++ b/aips/aip-10.md
@@ -140,7 +140,7 @@ Each object is stored in its own address represented by `Object<T>`. The underly
     - Abilities: `drop, store`
     - Data layout `{ self: ObjectId }`
 - `LinearTransferRef`
-    - Used to perform transferss.
+    - Used to perform transfers.
     - Enforces an entity can only transfer once, assuming that they do not have direct access to `TransferRef`
     - Abilities: `drop`
     - Data layout `{ self: ObjectId, owner: address }`


### PR DESCRIPTION
Fixes typo at AIP-10 under the `LinearTransferRef` 
![image](https://github.com/aptos-foundation/AIPs/assets/42067944/72c1a52a-4c18-4727-bfda-64dbee2bdb03)
