### PR TITLE
Mark AIP-40 as accepted in the file itself

### DIFF
--- a/aips/aip-40.md
+++ b/aips/aip-40.md
@@ -3,7 +3,7 @@ aip: 40
 title: Address Standard v1
 author: banool
 discussions-to (*optional):
-Status: Draft
+Status: Accepted
 last-call-end-date (*optional): 07/10/2023
 type: Standard
 created: 06/18/2023


### PR DESCRIPTION
The AIP is already marked as accepted based on the labels in the repo, this just updates the file.