### PR TITLE
Update TEMPLATE.md to put the question prompts in a quote box

### DIFF
--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -43,7 +43,7 @@ requires (*optional): <AIP number(s)>
 
 ...
 
-## Rationale
+## Alternative solutions
 
  > Explain why you submitted this proposal specifically over alternative solutions. Why is this the best possible outcome?
 
@@ -89,7 +89,10 @@ requires (*optional): <AIP number(s)>
 
 ### Suggested deployment timeline
 
- > When should community expect to see this deployed on devnet?
+ > Indicate a future release version as a *rough* estimate for when the community should expect to see this deployed on our three networks (e.g., release 1.7).
+ > You are responsible for updating this AIP with a better estimate, if any, after the AIP passes the gatekeeper’s design review.
+ >
+ > On devnet?
 
 ...
 

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -19,64 +19,109 @@ requires (*optional): <AIP number(s)>
 
 ## Summary
 
- > Include a brief description summarizing the intended change. This should be no more than a couple of sentences. Discuss the business impact and business value this change would impact.
+ > Include a brief description summarizing the intended change. This should be no more than a couple of sentences. 
+
+...
+
+ > Discuss the business impact and business value this change would impact.
+
+...
 
 ## Motivation
 
  > Describe the impetus for this change. What does it accomplish?
+
+...
  
- >  What might occur if we do not accept this proposal?
+ > What might occur if we do not accept this proposal?
+
+...
 
 ## Impact
 
  > Which audiences are impacted by this change? What type of action does the audience need to take?
 
+...
+
 ## Rationale
 
  > Explain why you submitted this proposal specifically over alternative solutions. Why is this the best possible outcome?
+
+...
 
 ## Specification
 
  > Describe in detail precisely how this proposal should be implemented. Include proposed design principles that should be followed in implementing this feature. Make the proposal specific enough to allow others to build upon it and perhaps even derive competing implementations.
 
+...
+
 ## Reference Implementation
 
  > This is an optional yet highly encouraged section where you may include an example of what you are seeking in this proposal. This can be in the form of code, diagrams, or even plain text. Ideally, we have a link to a living repository of code exemplifying the standard, or, for simpler cases, inline code.
+
+...
 
 ## Risks and Drawbacks
 
  > Express here the potential negative ramifications of taking on this proposal. What are the hazards?
 
+...
+
 ## Future Potential
 
  > Think through the evolution of this proposal well into the future. How do you see this playing out? What would this proposal result in in one year? In five years?
+
+...
 
 ## Timeline
 
 ### Suggested implementation timeline
 
  > Describe how long you expect the implementation effort to take, perhaps splitting it up into stages or milestones.
-  
+
+...
+
 ### Suggested developer platform support timeline
 
  > Describe the plan to have SDK, API, CLI, Indexer support for this feature is applicable. 
+
+...
 
 ### Suggested deployment timeline
 
  > When should community expect to see this deployed on devnet?
 
+...
+
  > On testnet?
 
+...
+
  > On mainnet?
+
+...
 
 ## Security Considerations
 
  > Has this change being audited by any auditing firm? 
+
+...
+
  > Any potential scams? What are the mitigation strategies?
+
+...
+
  > Any security implications/considerations?
+
+...
+
  > Any security design docs or auditing materials that can be shared?
+
+...
 
 ## Testing (optional)
 
  > What is the testing plan? How is this being tested?
+
+...
 

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -41,7 +41,7 @@ The additional context of the question being answered should be more helpful for
 
 ## Reference Implementation
 
- > This is an optional yet highly encouraged section where you may include an example of what you are seeking in this proposal. This can be in the form of code, diagrams, or even plain text. IDeally, we have a link to a living repository of code exemplifying the standard, or, for simpler cases, inline code.
+ > This is an optional yet highly encouraged section where you may include an example of what you are seeking in this proposal. This can be in the form of code, diagrams, or even plain text. Ideally, we have a link to a living repository of code exemplifying the standard, or, for simpler cases, inline code.
 
 ## Risks and Drawbacks
 

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -23,7 +23,9 @@ requires (*optional): <AIP number(s)>
 
 ## Motivation
 
- > Describe the impetus for this change. What does it accomplish? What might occur if we do not accept this proposal?
+ > Describe the impetus for this change. What does it accomplish?
+ 
+ >  What might occur if we do not accept this proposal?
 
 ## Impact
 

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -15,9 +15,7 @@ requires (*optional): <AIP number(s)>
   
 (Please give a temporary file name to your AIP when first drafting it, AIP manager will assign a number to it after reviewing.)
 
-(Please leave the questions in the "quote box" and provide your answer(s) directly below them, as opposed to removing the questions and providing an answer without context to the reader.) 
-
-The additional context of the question being answered should be more helpful for the reader to understand.)
+(Please leave the questions in the "quote box" and provide your answer(s) directly below them, as opposed to removing the questions and providing an answer without context to the reader. Including the question being answered as additional context should be very helpful for the reader to understand.)
 
 ## Summary
 

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -15,7 +15,9 @@ requires (*optional): <AIP number(s)>
   
 (Please give a temporary file name to your AIP when first drafting it, AIP manager will assign a number to it after reviewing.)
 
-(Consider leaving the questions in the "quote box" and provide the answer directly below them, as opposed to removing the questions. This will leave more context for the reader to understand.)
+(Please leave the questions in the "quote box" and provide your answer(s) directly below them, as opposed to removing the questions and providing an answer without context to the reader.) 
+
+The additional context of the question being answered should be more helpful for the reader to understand.)
 
 ## Summary
 

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -13,66 +13,68 @@ requires (*optional): <AIP number(s)>
 
 # AIP-X - (AIP title)
   
-(Please give a temporary file name to your AIP when first drafting it, AIP manager will assign a number to it after reviewing)
+(Please give a temporary file name to your AIP when first drafting it, AIP manager will assign a number to it after reviewing.)
+
+(Consider leaving the questions in the "quote box" and provide the answer directly below them, as opposed to removing the questions. This will leave more context for the reader to understand.)
 
 ## Summary
 
-Include a brief description summarizing the intended change. This should be no more than a couple of sentences. Discuss the business impact and business value this change would impact.
+ > Include a brief description summarizing the intended change. This should be no more than a couple of sentences. Discuss the business impact and business value this change would impact.
 
 ## Motivation
 
-Describe the impetus for this change. What does it accomplish? What might occur if we do not accept this proposal?
+ > Describe the impetus for this change. What does it accomplish? What might occur if we do not accept this proposal?
 
 ## Impact
 
-Which audiences are impacted by this change? What type of action does the audience need to take?
+ > Which audiences are impacted by this change? What type of action does the audience need to take?
 
 ## Rationale
 
-Explain why you submitted this proposal specifically over alternative solutions. Why is this the best possible outcome?
+ > Explain why you submitted this proposal specifically over alternative solutions. Why is this the best possible outcome?
 
 ## Specification
 
-Describe in detail precisely how this proposal should be implemented. Include proposed design principles that should be followed in implementing this feature. Make the proposal specific enough to allow others to build upon it and perhaps even derive competing implementations.
+ > Describe in detail precisely how this proposal should be implemented. Include proposed design principles that should be followed in implementing this feature. Make the proposal specific enough to allow others to build upon it and perhaps even derive competing implementations.
 
 ## Reference Implementation
 
-This is an optional yet highly encouraged section where you may include an example of what you are seeking in this proposal. This can be in the form of code, diagrams, or even plain text. IDeally, we have a link to a living repository of code exemplifying the standard, or, for simpler cases, inline code.
+ > This is an optional yet highly encouraged section where you may include an example of what you are seeking in this proposal. This can be in the form of code, diagrams, or even plain text. IDeally, we have a link to a living repository of code exemplifying the standard, or, for simpler cases, inline code.
 
 ## Risks and Drawbacks
 
-Express here the potential negative ramifications of taking on this proposal. What are the hazards?
+ > Express here the potential negative ramifications of taking on this proposal. What are the hazards?
 
 ## Future Potential
 
-Think through the evolution of this proposal well into the future. How do you see this playing out? What would this proposal result in in one year? In five years?
+ > Think through the evolution of this proposal well into the future. How do you see this playing out? What would this proposal result in in one year? In five years?
 
 ## Timeline
 
 ### Suggested implementation timeline
 
-Describe how long you expect the implementation effort to take, perhaps splitting it up into stages or milestones.
+ > Describe how long you expect the implementation effort to take, perhaps splitting it up into stages or milestones.
   
 ### Suggested developer platform support timeline
 
-Describe the plan to have SDK, API, CLI, Indexer support for this feature is applicable. 
+ > Describe the plan to have SDK, API, CLI, Indexer support for this feature is applicable. 
 
 ### Suggested deployment timeline
 
-When should community expect to see this deployed on devnet?
+ > When should community expect to see this deployed on devnet?
 
-On testnet?
+ > On testnet?
 
-On mainnet?
+ > On mainnet?
 
 ## Security Considerations
 
-Has this change being audited by any auditing firm? 
-Any potential scams? What are the mitigation strategies?
-Any security implications/considerations?
-Any security design docs or auditing materials that can be shared?
+ > Has this change being audited by any auditing firm? 
+ > Any potential scams? What are the mitigation strategies?
+ > Any security implications/considerations?
+ > Any security design docs or auditing materials that can be shared?
 
 ## Testing (optional)
 
-What is the testing plan? How is this being tested?
+ > What is the testing plan? How is this being tested?
 


### PR DESCRIPTION
I propose leaving the questions in the "quote box" so that AIP writers can provide the answer directly below them, as opposed to removing the questions and providing an answer without context. 

The additional context of the question being answered should be more helpful for the reader to understand.

It's also a good way for the AIP writer to ensure they are **actually answering** the **full** question!