### PR TITLE
Update AIP-41 to v1.2

### DIFF
--- a/aips/aip-41.md
+++ b/aips/aip-41.md
@@ -27,8 +27,6 @@ The proposed `randomness` module leverages an underlying _on-chain cryptographic
 
 The only thing this AIP does assume of the _on-chain randomness_ is that it is **unbiasable** and **unpredictable**, even by a malicious minority of the validators (as weighed by stake).
 
-As hinted above, the proposed `randomness` module would be part of the standard Aptos Move framework, under the `aptos_std` namespace.
-
 > Discuss the business impact and business value this change would impact.
 
 We believe that easy-to-use, secure randomness inside Move smart contracts will open up new possibilities for **randomized dapps (randapps)**: dapps whose core functionality requires an unbiasable and unpredictable source of entropy (e.g., games, randomized NFTs airdrops, raffles).
@@ -59,7 +57,7 @@ Only **Move developers** are “affected”: they need to learn how to use this 
 
 Instead of having a dedicated module for **on-chain randomness**, as part of the Aptos framework, we could provide Move APIs for verifying **external randomness** from off-chain beacons like [`drand`](https://drand.love) or oracles like Chainlink.
 
-In fact, we have already done this! We implemented Move cryptographic APIs that enable verifying `drand` randomness. See this example of a [simple Move lottery](https://github.com/aptos-labs/aptos-core/tree/ad3b32a7686549b567deb339296749b10a9e4e0e/aptos-move/move-examples/drand/sources) that relies on `drand`.
+In fact, we have already done this: see this example of a [simple Move lottery](https://github.com/aptos-labs/aptos-core/tree/ad3b32a7686549b567deb339296749b10a9e4e0e/aptos-move/move-examples/drand/sources) that relies on the `drand` randomness beacon.
 
 Nonetheless, **relying on an external beacon has several disadvantages**:
 
@@ -75,51 +73,45 @@ Nonetheless, **relying on an external beacon has several disadvantages**:
 
 We are proposing a new `aptos_std::randomness` Move module for generating publicly-verifiable randomness in Move smart contracts.
 
-### Rust-like randomness API
+### `randomness` API
 
-The proposed module has a simple & hard-to-misuse interface:
+The proposed module has a simple yet hard-to-misuse interface:
 
-- Any contract can call `randomness::rng()` to create a **random number generator (RNG)**, which will be seeded with unique **entropy** (e.g., 256 uniform, unpredictable bits) from the on-chain randomnes beacon.
-- Once created, an RNG can be passed in to helper functions to sample random objects.
-  - For example, given an RNG `rng`, a call to `randomness::u64_range(&mut rng, 0, n)` uniformly samples a number in the range `[0, n)`.
-  - Or, a call to `randomness::permutation(&mut rng, n)` returns a random shuffle of the vector `[0, 1, 2, ..., n-1]`.
-- Importantly, these helper functions **mutate** the RNG, updating its entropy.
-- This way the contract may safely sample multiple objects using the same `rng`: 
-  - e.g., sample a `u64` via  `randomness::u64_integer(&mut rng)` and then sample a `u256` via `randomness::u256_integer(&mut rng)`.
-- **Similarly,** secondary calls to `randomness::rng()`, whether from the same module or from a different module, will also return a mutated RNG seeded with *different* entropy (except with negligble probability due to collisions when sampling 256-bit numbers uniformly).
+The module offers a suite functions for randomly-sampling a wide-variety of objects (integers, bytes, shuffles, etc). For example:
 
-The `randomness` module follows below:
+- `randomness::u64_integer()` uniformly samples a 64-bit unsigned integer
+- `randomness::bytes(0, n)` uniformly samples a vector of `n` bytes.
+- `randomness::permutation(n)` returns a random shuffle of the vector `[0, 1, 2, ..., n-1]`.
+
+Contracts can safely sample multiple objects via repeated calls to these functions. For example, the code below samples two `u64`'s and one `u256`:
+
+```rust
+let n1 = randomness::u64_integer();
+let n2 = randomness::u64_integer();
+let n3 = randomness::u256_integer();
+```
+
+The full `randomness` module follows below:
 
 ```rust
 module aptos_std::randomness {
     use std::vector;
-
-    /// A _random number generator (RNG)_ object that stores entropy from the on-chain randomness beacon.
-    ///
-    /// This RNG object can be used to produce one or more random numbers, random permutation, etc.
-    struct RandomNumberGenerator has drop { /* ... */ }
-
-    /// Returns a uniquely-seeded RNG.
-    ///
-    /// Repeated calls to this function will return an RNG with a different seed. This is to
-    /// prevent developers from accidentally calling `rng` twice and generating the same randomness.
-    ///
-    /// Calls to this function **MUST** only be made from private entry functions in modules that have
-    /// no other functions. This is to prevent _test-and-abort_ attacks.
-    public fun rng(): RandomNumberGenerator { /* ... */ }
+  
+    /// Generates `n` bytes uniformly at random.
+    public fun bytes(n: u64): vector<u8> { /* ... */ }
 
     /// Generates a number uniformly at random.
-    public fun u64_integer(rng: &mut RandomNumberGenerator): u64 { /* ... */ }
-    public fun u256_integer(rng: &mut RandomNumberGenerator): u256 { /* ... */ }
+    public fun u64_integer(): u64 { /* ... */ }
+    public fun u256_integer(): u256 { /* ... */ }
 
     /// Generates a number $n \in [min_incl, max_excl)$ uniformly at random.
-    public fun u64_range(rng: &mut RandomNumberGenerator, _min_incl: u64, _max_excl: u64): u64 { /* ... */ }
-    public fun u256_range(rng: &mut RandomNumberGenerator, _min_incl: u256, _max_excl: u256): u256 { /* ... */ }
+    public fun u64_range(min_incl: u64, max_excl: u64): u64 { /* ... */ }
+    public fun u256_range(min_incl: u256, max_excl: u256): u256 { /* ... */ }
 
     /* Similar methods for u8, u16, u32, u64, and u128. */
 
     /// Generate a permutation of `[0, 1, ..., n-1]` uniformly at random.
-    public fun permutation(rng: &mut RandomNumberGenerator, n: u64): vector<u64> { /* ... */ }
+    public fun permutation(n: u64): vector<u64> { /* ... */ }
 
     #[test_only]
     /// Test-only function to set the entropy in the RNG to a specific value, which is useful for
@@ -184,7 +176,7 @@ module lottery::lottery {
     }
 
     /// Stores the signer capability for the resource account.
-    struct Info has key {
+    struct Credentials has key {
         // Signer capability for the resource account storing the coins that can be won
         signer_cap: account::SignerCapability,
     }
@@ -206,17 +198,20 @@ module lottery::lottery {
         // Store the signer cap for the resource account in the resource account itself
         move_to(
             resource_account,
-            Info { signer_cap }
+            Credentials { signer_cap }
         );
     }
 
+    /// The minimum time the lottery must be open for before anyone can call
+    /// `decide_winners`
     public fun get_minimum_lottery_duration_in_secs(): u64 { MINIMUM_LOTTERY_DURATION_SECS }
 
+    /// The price of buying a lottery ticket.
     public fun get_ticket_price(): u64 { TICKET_PRICE }
 
     /// Allows anyone to (re)start the lottery.
-    public entry fun start_lottery() acquires Info {
-        let info = borrow_global<Info>(@lottery);
+    public entry fun start_lottery() acquires Credentials {
+        let info = borrow_global<Credentials>(@lottery);
         let resource_account = account::create_signer_with_capability(&info.signer_cap);
 
         let lottery = Lottery {
@@ -243,10 +238,17 @@ module lottery::lottery {
         // ...and issue a ticket for that user
         vector::push_back(&mut lottery.tickets, signer::address_of(user))
     }
-
+  
+		/// Securely wraps around `decide_winners_internal` so it can only be called
+    /// as a top-level call from a TXN, preventing **test-and-abort** attacks (see
+    /// [AIP-41](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-41.md)).
+    entry fun decide_winners() acquires Lottery, Credentials {
+        decide_winners_internal();
+    }
+  
     /// Allows anyone to close the lottery (if enough time has elapsed & more than
     /// 1 user bought tickets) and to draw a random winner.
-    entry fun decide_winners(): address acquires Lottery, Info {
+    public(friend) fun decide_winners_internal(): address acquires Lottery, Credentials {
         let lottery = borrow_global_mut<Lottery>(@lottery);
 
         // Make sure the lottery is not being closed too early...
@@ -262,13 +264,15 @@ module lottery::lottery {
 
         // Pick a random winner by permuting the vector [0, 1, 2, ..., n-1], and
         // where n = |lottery.tickets|
-        let rng = randomness::rng();
-        let perm = randomness::permutation(&mut rng, vector::length(&lottery.tickets));
-        let winner_idx = *vector::borrow(&perm, 0);
+        let winner_idx = randomness::u64_range(
+            0,
+            vector::length(&lottery.tickets)
+        );
         let winner = *vector::borrow(&lottery.tickets, winner_idx);
 
         // Pay the winner
-        let signer = get_signer();
+        let creds = borrow_global<Credentials>(@lottery);
+        let signer = account::create_signer_with_capability(&creds.signer_cap);
         let balance = coin::balance<AptosCoin>(signer::address_of(&signer));
 
         coin::transfer<AptosCoin>(
@@ -279,35 +283,61 @@ module lottery::lottery {
 
         winner
     }
-
-    /// Returns a signer for the resource account.
-    fun get_signer(): signer acquires Info {
-        let info = borrow_global<Info>(@lottery);
-
-        account::create_signer_with_capability(&info.signer_cap)
-    }
 }
 ```
 
-Note that the `lottery::decide_winners` function is marked as **private** `entry`. This ensures that calls to it cannot be made from Move scripts nor from any other functions outside the `lottery` module. In other words, `lottery::decide_winners` can only be called as the top-level call in a TXN.
+Note that the `lottery::decide_winners` function is marked as **private** `entry`. 
 
-This prevents [test-and-abort attacks](#test-and-abort-attacks), which are discussed below. 
+This is to prevent [test-and-abort attacks](#test-and-abort-attacks), which we discuss later.
+
+Specifically, it ensures that calls to `decide_winners` cannot be made from Move scripts nor from any other functions outside the `lottery` module. Such calls could test the outcome of `decide_winners` and abort, biasing the outcome of the lottery (see [“Test-and-abort attacks”](#test-and-abort-attacks)).
+
+## Open questions
+
+**O1:** Should the `randomness` module be part of `aptos_framework` rather than `aptos_std`? One reason to keep it in `aptos_std` is in case it might be needed by some of the cryptographic modules there (e.g., perhaps interactive ZKP verifiers that use public coins could use the `randomness` module).
+
+**O2:** Support for private `entry `functions might not be fully implemented: i.e., entry functions could still be wrapped around in a Move script potentially. Or perhaps they are not even callable from a TXN.
+
+## Reference Implementation
+
+ > This is an optional yet highly encouraged section where you may include an example of what you are seeking in this proposal. This can be in the form of code, diagrams, or even plain text. Ideally, we have a link to a living repository of code exemplifying the standard, or, for simpler cases, inline code.
+
+There is a reference (albeit **dummy**) implementation of the proposed `aptos_std::randomness` API and an actual implementation of the `lottery` example [in this PR](https://github.com/aptos-labs/aptos-core/pull/9581) (which should merge and be available soon [here](https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/move-examples/lottery).)
+
+## Risks and Drawbacks
+
+ > Express here the potential negative ramifications of taking on this proposal. What are the hazards?
+
+### Accidentally re-generating the same randomness
+
+It should be impossible to misuse the API to re-sample a previously-sampled piece of randomness (excluding naturally-arising collisions, of course).
+
+An example of this would be if a developer expects to sample two `u64` integers `n1` and `n2` , but the API only samples once. In other words, `n1` and `n2` always end up equal:
+
+```
+let n1 = randomness::u64_integer();
+let n2 = randomness::u64_integer();
+
+if (n1 != n2) {
+   // This code is never reached.
+}
+```
 
 ### Test-and-abort attacks
 
 Smart contract platforms are an inherently-adversarial environment to deploy randomness in.
 
-The **key problem** with having a Move function act based on on-chain randomness (e.g., from `randomness::u64_integer`), is that the **effects** of the function call can be **tested for** by calling this function from another module (or from a Move script) and **aborting** if the outcomes are not the desired ones.
+The **key problem** with having a Move function’s execution be influenced by on-chain randomness (e.g., by `randomness::u64_integer`), is that the **effects** of its execution can be **tested for** by calling the function from another module (or from a Move script) and **aborting** if the outcomes are not the desired ones.
 
 #### An example attack
 
-Concretely, if `lottery::decide_winners` were a `public entry` function instead of a **private** entry function:
+Concretely, suppose `lottery::decide_winners` were a `public entry` function instead of a **private** entry function:
 
 ```rust
-public entry fun decide_winners(): address acquires Lottery, Info { /* ... */}
+public entry fun decide_winners(): address acquires Lottery, Credentials { /* ... */}
 ```
 
-Then, a TXN with the following Move script could be used to attack it via **test-and-abort**:
+Then, a TXN that contains the following Move script could be used to attack it via **test-and-abort**:
 
 ```rust
 script {
@@ -335,53 +365,13 @@ script {
 }
 ```
 
-## Open questions
+### Expressivity
 
-**O1:** Should the `randomness` module be part of `aptos_framework` rather than `aptos_std`?
+Another concern is the **API is not expressive enough**. 
 
-## Reference Implementation
+Fortunately, the `randomness::bytes` method should allow implementing any complicated sampling of other objects (e.g., 512-bit numbers). 
 
- > This is an optional yet highly encouraged section where you may include an example of what you are seeking in this proposal. This can be in the form of code, diagrams, or even plain text. Ideally, we have a link to a living repository of code exemplifying the standard, or, for simpler cases, inline code.
-
-There is a reference **dummy** implementation of the proposed `aptos_std::randomness` API and a **proper** implementation of the `lottery` example [in this PR](https://github.com/aptos-labs/aptos-core/pull/9581), which should be merged soon.
-
-**TODO:** Update with link to `move-examples/` code once merged.
-
-## Risks and Drawbacks
-
- > Express here the potential negative ramifications of taking on this proposal. What are the hazards?
-
-There is a risk of proposing an **easy-to-misuse** API. 
-
-### Accidentally re-generating the same randomness
-
-It should be impossible to misuse the API to re-sample a previously-sampled piece of randomness (excluding allowed collisions, of course).
-
-An example of this would be if a developer creates two RNG objects:
-
-```
-let rng1 = randomness::rng();
-let rng2 = randomness::rng();
-```
-
-...and uses each one to sample two, say, `u256` integers `n1` and `n2` :
-
-```
-let n1 = randomness::u256(&mut rng1);
-let n2 = randomness::u256(&mut rng2);
-```
-
-What the developer does **NOT** want is for `n1` and `n2` to always end up equal because they were sampled from the same underlying RNG with the same entropy.
-
-This can be avoided by ensuring that the entropy underneath `rng2` will (**likely**) be different than the entropy  on `rng1`.
-
-As a result, developers **cannot make a mistake** and accidentally sample once when they expected to sample twice.
-
-**Why will the entropy only be “likely” different?**: We say “likely” due to the underlying cryptographic implementation of the entropy mutation, which will have a negligible probability (e.g.., $< 1/2^{128}$) of not actually mutating the entropy (e.g., due to collisions in hash functions).
-
-**Note:** As an alternative, the API could also **abort** upon seeing a second `randomness::rng()` call in the same TXN. However, it is unclear if this would prevent use-cases where two `entry` functions call each other yet both make calls to `randomness::rng()`.
-
-Another concern is the **API is not expressive enough**. For example, if there is no support for safely converting the `Randomness` object into a random shuffle (or a uniform integer, or a random choice from a vector, etc.), developers might implement this themselves but do it incorrectly.
+Furthermore, if needed, the `randomness` module can be upgraded with extra functionality.
 
 ## Future Potential
 
@@ -397,7 +387,7 @@ In addition, this proposal could provide a trustworthy randomness beacon for ext
 
  > Describe how long you expect the implementation effort to take, perhaps splitting it up into stages or milestones.
 
-**Not applicable**: This AIP is strictly about the proposed API, and not its implementation, which is complex and will be the scope of a different, future AIP.
+**Not applicable**: This AIP is strictly about the proposed API, and not its cryptographic implementation, which will be the scope of a different, future AIP.
 
 ### Suggested developer platform support timeline
 
@@ -405,7 +395,7 @@ In addition, this proposal could provide a trustworthy randomness beacon for ext
 
 It may be worth investigating whether randomness calls (and their outputs) need to be indexed (e.g., should events be emitted?).
 
-This could be important to make it easier to **publicly-verify** our randomness. Specifically, anyone could look at the `randomness`-related events emitted by a contract to fetch its history of generated randomness and the auxiliary inputs that were used to derive it (e.g., the block #, TXN hash, module name, calling function name, etc.).
+This could be important to make it easier to **publicly-verify** the randomness produced by randapps. Specifically, anyone could look at the `randomness`-related events emitted by a contract to fetch its verifiable history of generated randomness.
 
 ### Suggested deployment timeline
 
@@ -415,13 +405,13 @@ This could be important to make it easier to **publicly-verify** our randomness.
 > 
 > On mainnet?
 
-See [“Suggested implementation timeline”](#suggested-implementation-timeline): the implementation is complex and will be the scope of a different, future AIP.
+See [“Suggested implementation timeline”](#suggested-implementation-timeline): the cryptographic implementation will be the scope of a different, future AIP.
 
 ## Security Considerations
 
 > Has this change being audited by any auditing firm?
 
-Not yet, but it will be audited by the time it is deployed. Updates will be posted here.
+Not yet, but it will be audited by the time it is deployed. Updates will be posted here (**TODO**).
 
 > Any security design docs or auditing materials that can be shared?
 
@@ -443,21 +433,76 @@ When implementing on-chain randomness with a **secrecy-based approach** (e.g., a
 
 While contracts can mitigate against this by (carefully) incorporating external randomness or delay functions, this defeats many of the advantages of on-chain randomness.
 
-### Security consideration: linter for `randomness::rng()` calls.
+### Security consideration: Preventing test-and-abort attacks
 
-**TODO:** Write
+The defense discussed in [“Test-and-abort attacks”](#test-and-abort-attacks) assumed that developers make proper use of **private** entry functions as the only entry point into their randapp. Unfortuantely, developers are fallible. Therefore, it is important to prevent **accidentally-introduced bugs**.
+
+We discuss two defenses below that could be used to enforce the proper usage of **private** `entry` functions as the only gateway into randapps.
+
+#### Linter-based checks
+
+A linter check could be implemented to ensure that the `randomness` function calls that sample objects, such as `randomness::u64_integer`, are only reachable via a call to a `private` entry function.
+
+For example, this is the case in the `lottery` example, where:
+
+- The winner is picked via `randomness::u64_range`,
+- ...which is called from the `public(friend)` function `decide_winners_internal`, 
+- ...which in turn is only callable from the private `entry ` function `decide_winners`.
+
+**Advantages:**
+
+- This defense could be made part of the default linter checks in the `aptos move` CLI compiler.
+
+**Disadvantages:**
+
+- Some developers could skip over this defense by using a custom compiler or writing bytecode directly.
+
+#### Callstack-based checks
+
+The check described above could also be done at runtime by (somehow) introspecting on the Move VM callstack when a function call such as `randomness::u64_integer` is made. 
+
+**Advantages:** 
+
+- This might not be to difficult to implement if `randomness::u64_integer` is a Move native function via `SafeNativeContext` -> `NativeContext` -> `Interpreter` -> `CallStack` -> check `def_is_friend_or_private` of every function in the call stack (need to add a `traverse` function though).
+- This defense will **always** work, whereas the linter-based defense can be skipped by some developers.
+
+**Disadvantages:**
+
+- This defense is rather aggresive as it interferes with the semantics of the Move language by aborting the execution of vulnerable randomness function calls, which would normally proceed without issue.
 
 ## Testing (optional)
 
 > What is the testing plan? How is this being tested?
 
-See [“Suggested implementation timeline”](#suggested-implementation-timeline): the implementation is complex and will be the scope of a different, future AIP.
+As per [“Suggested implementation timeline”](#suggested-implementation-timeline), the cryptographic implementation will be the scope of a different, future AIP.
 
-Instead, the “testing” plan is to gather feedback from Move developers and the wider ecosystem on whether this API is "right" via AIP discussions.
+The testing plan currently consists of:
 
-## Apendix 
+- Gathering feedback from the Move ecosystem on the API via AIP discussions, developer discussions, etc.
+- Testing that the support for private `entry` functions is fully-implemented in the Move VM
+- Testing that the linter-based checks (or the callstack-based checks) do indeed catch misuses of the `randomness` API
+
+## Acknowledgements
+
+Thanks to the individual contributors in [this AIP’s discussion](https://github.com/aptos-foundation/AIPs/issues/185).
+
+Thanks to the Move design review team for their helpful feedback.
+
+Thanks to Kevin Hoang, Igor Kabiljo and Rati Gelashvili for their help on mitigating against _test-and-abort_ attacks.
+
+Thanks to Junkil Park for further simplifying the API.
+
+## Changelog 
 
 For posterity, past versions of this AIP were:
 
-- [v1.0](https://github.com/aptos-foundation/AIPs/blob/4577f34c8df6c52a213223cd62472ea59e3861ef/aips/aip-41.md), which included a more complicated `randomness` API
-- [v1.1](https://github.com/aptos-foundation/AIPs/blob/3e40b4e630eb8aa517b617799f8e578f5f937682/aips/aip-41.md), which failed to account for _test-and-abort_ attacks via Move scripts or external modules.
+- [v1.0](https://github.com/aptos-foundation/AIPs/blob/4577f34c8df6c52a213223cd62472ea59e3861ef/aips/aip-41.md)
+  - Initial version of the `randomness` API
+- [v1.1](https://github.com/aptos-foundation/AIPs/blob/3e40b4e630eb8aa517b617799f8e578f5f937682/aips/aip-41.md), 
+  - Switched API design to be `RandomNumberGenerator`-based
+  - See [diff from v1.0 here](https://github.com/aptos-foundation/AIPs/compare/4577f34c8df6c52a213223cd62472ea59e3861ef..3e40b4e630eb8aa517b617799f8e578f5f937682?short_path=33dc9b1#diff-33dc9b179818e3c972be69b5f214313b233e2338fef599626ebe4895f4e5dc51).
+- v1.2 (current):
+  - Added protection against _test-and-abort_ attacks
+  - Further simplified API by removing the `RandomNumberGenerator` struct.
+  - Discussed linter-based checks and callstack-based checks for improper uses of the `randomness` APIs.
+  - See [diff from v1.1 here](https://github.com/aptos-foundation/AIPs/compare/3e40b4e630eb8aa517b617799f8e578f5f937682..HEAD).


### PR DESCRIPTION
- Added protection against _test-and-abort_ attacks
- Further simplified API by removing the `RandomNumberGenerator` struct.
- Discussed linter-based checks and callstack-based checks for improper uses of the `randomness` APIs.