### PR TITLE
Update AIP 114 to remove featureflag

### DIFF
--- a/aips/aip-114.md
+++ b/aips/aip-114.md
@@ -1,14 +1,14 @@
 ---
 aip: 114
 title: Increase Coin Symbol Length
-author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s). Details are below.>
-discussions-to (*optional): <a url pointing to the official discussion thread>
+author: @gregnazario
+discussions-to (*optional): N/A
 Status: Draft
-last-call-end-date (*optional): <mm/dd/yyyy the last date to leave feedbacks and reviews>
+last-call-end-date (*optional): N/A
 type: Standard (Framework)
-created: 02/01/2024
-updated (*optional): <mm/dd/yyyy>
-requires (*optional): <AIP number(s)>
+created: 02/01/2025
+updated (*optional): 02/24/2025
+requires (*optional): N/A
 ---
 
 # AIP-114 - Increase Coin Symbol Byte Length
@@ -16,8 +16,8 @@ requires (*optional): <AIP number(s)>
 ## Summary
 
 Currently, emojis are 3 bytes, and could be longer up to 32 bytes. This AIP proposes to increase the coin and FA symbol
-byte length to allow for more combinations of emojis to be used as a coin symbol. This is an increase behind a feature
-flag to increase from 10 bytes to 32 bytes, and will need to adjust the indexer storage accordingly.
+byte length to allow for more combinations of emojis to be used as a coin symbol. This is an increase from 10 bytes to 32 bytes,
+and adjusts the indexer storage accordingly.
 
 Goal here is to allow for more flexibility in coin symbols, and to allow for more unique coin symbols to be used.
 
@@ -29,7 +29,7 @@ Not changing anything but the number of bytes allowed to be stored, and the Apto
 
 ## High-level Overview
 
-Increases the limit to 32 bytes, adds a feature flag to enable this, and adjusts the indexer storage to allow for this.
+Increases the limit to 32 bytes, and adjusts the indexer storage to allow for this.
 
 ## Impact
 
@@ -49,7 +49,7 @@ None, it's currently limited to 10 bytes, there's no other way to stick with UTF
 
 ## Reference Implementation
 
-Has a feature flag associated. See https://github.com/aptos-labs/aptos-core/pull/15846
+See https://github.com/aptos-labs/aptos-core/pull/15846, increases to 32 bytes.
 
 ## Testing
 


### PR DESCRIPTION
Discussed, no feature flag needed, just use framework deployment to reduce governance overhead.