### PR TITLE
AIP: Validator Priority Fees

### DIFF
--- a/aips/aip-126.md
+++ b/aips/aip-126.md
@@ -1,5 +1,5 @@
 ---
-aip: (this is determined by the AIP Manager, leave it empty when drafting)
+aip: 126
 title: Validator Priority Fees
 author: guy-goren, Guoteng Rao, Zekun Li
 Status: Draft
@@ -9,12 +9,8 @@ updated (*optional): <mm/dd/yyyy>
 requires (*optional): <AIP number(s)>
 ---
 
-# AIP-X - Validator Priority Fees
+# AIP-126 - Validator Priority Fees
   
-(Please give a temporary file name to your AIP when first drafting it, such as `aip-x.md`. The AIP manager will assign a number to it after reviewing.)
-
-(Please remove the questions in the "quote box". Provide complete context to the questions being asked in the content that you provide.)
-
 ## Summary
 
 There is currently no mechanism in the Aptos protocol that incentivizes validators to prioritize higher-priced transactions. As a result, no built-in priority fee market exists, which encourages the emergence of informal or "black market" mechanisms for transaction ordering. This becomes increasingly problematic as trading use cases grow, particularly those involving arbitrage opportunities, where fair and open competition over ordering is essential.


### PR DESCRIPTION
This AIP proposes a mechanism for Validator Priority Fees in Aptos.
The motivation, implementation outline, and rationale are detailed in the markdown file under aips/Validator Priority Fees.md