### PR TITLE
[proposal] Multisig account timelock

### DIFF
--- a/aips/aip-145-multisig-account-timelock.md
+++ b/aips/aip-145-multisig-account-timelock.md
@@ -1,0 +1,208 @@
+---
+aip: 145
+title: Multisig Account Timelock
+author: gregnazario (https://github.com/gregnazario)
+discussions-to: <TODO>
+Status: Draft
+type: Standard (Framework)
+created: 04/09/2026
+updated:
+requires: AIP-12, AIP-77
+---
+
+# AIP-145 - Multisig Account Timelock
+
+## Summary
+
+This AIP proposes adding an opt-in timelock mechanism to Aptos multisig accounts. Once a proposed transaction reaches approval quorum, execution is delayed by a configurable period (1 hour to 14 days). A separate, higher signature threshold can be configured to bypass the timelock and allow immediate execution when urgency demands it.
+
+## Motivation
+
+Multisig accounts on Aptos are used to manage treasuries, upgrade smart contracts, and govern DAOs. Today, once a transaction reaches the required number of approvals, any owner can execute it immediately. This creates risk in several scenarios:
+
+1. **Compromised keys**: If an attacker compromises enough owner keys to meet quorum, they can drain funds or execute malicious upgrades instantly, leaving no time for detection or response.
+2. **Social engineering**: An owner could be tricked into approving a malicious transaction. Without a delay, there is no window for other owners to review and reject before execution.
+3. **Operational safety**: Organizations often want a "cool-down" period between approval and execution to allow for final review, compliance checks, or stakeholder notification.
+
+Timelocks are a well-established pattern in blockchain governance (e.g., Compound's Timelock, OpenZeppelin's TimelockController). This proposal brings the same protection to Aptos multisig accounts while preserving the ability to act quickly via a higher approval threshold when genuinely needed.
+
+## Impact
+
+- **Existing multisig accounts**: Completely unaffected. The timelock is opt-in; accounts without it configured continue to work exactly as before.
+- **New and upgraded accounts**: Owners can configure a timelock at any time via a multisig transaction. Once configured, all subsequent executions are subject to the delay unless the bypass threshold is met.
+- **Wallet and SDK developers**: Should surface the timelock status (duration and bypass threshold) in their UIs and handle the `ETIMELOCK_NOT_EXPIRED` prologue error gracefully (e.g., showing "Transaction is timelocked until ...").
+- **Rejections are unaffected**: The timelock applies only to execution, not rejection. If enough owners reject a transaction, it can be removed immediately. The timelock protects against hasty *execution*, not hasty *cancellation*.
+
+## Specification
+
+### New Resource
+
+A new resource is stored at the multisig account address alongside the existing `MultisigAccount`:
+
+```move
+struct MultisigAccountTimelock has key {
+    /// Seconds that must elapse after quorum before execution is allowed.
+    timelock_secs: u64,
+    /// Number of approvals that bypass the timelock for immediate execution.
+    /// Must be > num_signatures_required and <= num_owners when active.
+    bypass_num_signatures: u64,
+    /// Maps transaction sequence_number -> timestamp when quorum was first reached.
+    approval_timestamps: Table<u64, u64>,
+}
+```
+
+A separate resource is used because Move structs that are already stored on-chain cannot have new fields added. This preserves full backward compatibility with the existing `MultisigAccount` and `MultisigTransaction` structs.
+
+### Configuration
+
+Timelock is configured via a new entry function that can only be invoked as a multisig transaction payload (not `public`, preventing other modules from calling it with a borrowed signer):
+
+```move
+entry fun update_timelock(
+    multisig_account: &signer,
+    new_timelock_secs: u64,
+    new_bypass_num_signatures: u64,
+) acquires MultisigAccount, MultisigAccountTimelock;
+```
+
+**To enable**: `new_timelock_secs > 0` and `new_bypass_num_signatures > num_signatures_required` and `new_bypass_num_signatures <= num_owners`.
+
+**To disable**: `new_timelock_secs = 0` and `new_bypass_num_signatures = 0`. Disabling itself goes through the active timelock (the transaction must wait out the delay or meet the bypass threshold).
+
+**Bounds**: `timelock_secs` must be between `MIN_TIMELOCK_PERIOD` (3,600 seconds / 1 hour) and `MAX_TIMELOCK_PERIOD` (1,209,600 seconds / 14 days).
+
+### Execution Logic
+
+A transaction can be executed when:
+
+1. It has reached approval quorum (`num_approvals >= num_signatures_required`), AND either:
+   - **(a)** The number of approvals meets the bypass threshold (`num_approvals >= bypass_num_signatures`), allowing immediate execution, OR
+   - **(b)** Sufficient time has elapsed since quorum was first reached: `now_seconds() >= approval_timestamp + timelock_secs`.
+
+If neither condition is met, the transaction prologue rejects with `ETIMELOCK_NOT_EXPIRED`.
+
+### Approval Timestamp Tracking
+
+The `approval_timestamps` table records when each transaction first reached quorum:
+
+| Scenario | Behavior |
+|----------|----------|
+| k-th approval meets quorum | Timestamp recorded with `now_seconds()` |
+| Additional approval after quorum | Timestamp preserved (clock does NOT restart) |
+| Vote change causes quorum loss | Timestamp removed (clock resets) |
+| Quorum restored after loss | New timestamp recorded (clock restarts) |
+| Transaction executed or rejected | Timestamp entry cleaned up |
+| 1-of-N multisig, creator proposes | Timestamp set at creation (auto-approval meets quorum) |
+
+### Invariant Enforcement
+
+When the timelock is active, the following invariants are maintained:
+
+1. `bypass_num_signatures > num_signatures_required`
+2. `bypass_num_signatures <= owners.length()`
+
+These are enforced both when configuring the timelock (`update_timelock`) and when owners or thresholds change (`update_owner_schema`). Owner removals or threshold increases that would violate these invariants are rejected.
+
+### New Error Codes
+
+| Code | Name | Description |
+|------|------|-------------|
+| 2012 | `ETIMELOCK_NOT_EXPIRED` | Prologue error: quorum met but timelock delay has not elapsed |
+| 21 | `EINVALID_TIMELOCK_CONFIG` | `timelock_secs` and `bypass_num_signatures` must both be positive or both zero |
+| 22 | `EINVALID_TIMELOCK_DURATION` | `timelock_secs` outside valid range (1 hour – 14 days) |
+| 23 | `EINVALID_TIMELOCK_BYPASS_THRESHOLD` | `bypass_num_signatures` not in valid range |
+
+### New Event
+
+```move
+#[event]
+struct TimelockUpdated has drop, store {
+    multisig_account: address,
+    old_timelock_secs: u64,
+    new_timelock_secs: u64,
+    old_bypass_num_signatures: u64,
+    new_bypass_num_signatures: u64,
+}
+```
+
+### New View Functions
+
+```move
+#[view]
+public fun timelock_secs(multisig_account: address): u64;
+
+#[view]
+public fun timelock_bypass_num_signatures(multisig_account: address): u64;
+```
+
+Both return `0` if no timelock is configured.
+
+## Implementation Details
+
+All timelock resource access is encapsulated in four non-inline helper functions:
+
+1. **`maybe_update_approval_timestamp`** — Called after every vote and transaction creation. Records or removes the quorum timestamp.
+2. **`assert_timelock_expired`** — Called during `validate_multisig_transaction` (prologue). Enforces the delay or bypass.
+3. **`maybe_remove_approval_timestamp`** — Called on transaction execution or rejection. Cleans up the timestamp entry.
+4. **`validate_timelock_invariants`** — Called after owner/threshold changes. Ensures bypass invariants hold.
+
+Because these are non-inline functions, their `acquires MultisigAccountTimelock` annotation does **not** propagate to callers. This means no existing function signature or `acquires` clause changes — full ABI compatibility.
+
+### Changes to Existing Functions
+
+| Function | Change |
+|----------|--------|
+| `vote_transanction` | Calls `maybe_update_approval_timestamp` after recording the vote |
+| `add_transaction` | Calls `maybe_update_approval_timestamp` after creator auto-approval |
+| `validate_multisig_transaction` | Computes effective approvals (including implicit executor vote), calls `assert_timelock_expired` |
+| `transaction_execution_cleanup_common` | Calls `maybe_remove_approval_timestamp` |
+| `execute_rejected_transaction` | Calls `maybe_remove_approval_timestamp` |
+| `update_owner_schema` | Calls `validate_timelock_invariants` at the end |
+
+**No existing struct definitions change. No existing function signatures change.**
+
+### Behavioral Notes
+
+- **Implicit executor vote**: When the v2 enhancement feature is enabled, the executor's implicit approval counts toward both the regular and bypass thresholds. However, if the implicit vote is what first reaches quorum, no timestamp exists yet — the executor must first explicitly approve (starting the clock), wait out the timelock, then execute. This prevents timelock circumvention via implicit votes.
+- **Enabling on existing accounts**: Pending transactions that already have quorum will NOT have timestamps recorded. A fresh vote (even a redundant re-approval) is needed to start the clock. This is intentional — enabling a timelock is a security hardening step.
+- **Overflow prevention**: Time comparison uses `now_seconds() - approval_time >= timelock_secs` (subtraction-based) rather than `now_seconds() >= approval_time + timelock_secs` to prevent potential overflow.
+
+## Reference Implementation
+
+https://github.com/gregnazario/aptos-core/tree/multisig-timelock
+
+## Testing
+
+The implementation includes 13 unit tests covering:
+
+| Test | What it validates |
+|------|-------------------|
+| `test_update_timelock` | Configure timelock, verify via view functions, then disable |
+| `test_update_timelock_invalid_config_should_fail` | Mixed zero/non-zero config rejected |
+| `test_update_timelock_bypass_not_greater_than_threshold_should_fail` | `bypass <= num_signatures_required` rejected |
+| `test_update_timelock_bypass_exceeds_owners_should_fail` | `bypass > num_owners` rejected |
+| `test_execute_before_timelock_expires_should_fail` | Execution blocked during delay period |
+| `test_execute_after_timelock_expires` | Execution succeeds after delay elapses |
+| `test_execute_with_bypass_skips_timelock` | Bypass threshold allows immediate execution |
+| `test_timelock_resets_when_quorum_lost` | Clock resets when quorum is lost and re-established |
+| `test_timelock_set_immediately_for_single_sig` | 1-of-N: timestamp set at creation |
+| `test_remove_owners_invalidates_bypass_should_fail` | Owner removal blocked if it breaks bypass invariant |
+| `test_update_threshold_invalidates_bypass_should_fail` | Threshold increase blocked if it breaks bypass invariant |
+| `test_no_timelock_executes_normally` | Existing behavior unchanged without timelock |
+| `test_disable_timelock_allows_immediate_execution` | Disabling restores immediate execution |
+
+These will also be tested on devnet and testnet prior to mainnet deployment.
+
+## Security Considerations
+
+- **Timelock protects against key compromise**: A configurable delay gives honest owners time to detect unauthorized activity and reject malicious transactions before execution.
+- **Bypass threshold is a deliberate escape hatch**: The higher threshold allows rapid response when genuinely needed (e.g., emergency security patches) while still requiring broader consensus than normal operations.
+- **Disabling the timelock requires going through the timelock**: An attacker who compromises enough keys to meet regular quorum but not the bypass threshold cannot immediately disable the timelock — they must wait out the delay, during which the attack can be detected.
+- **Rejections bypass the timelock**: This is intentional. If owners detect a malicious pending transaction, they should be able to remove it immediately without waiting.
+- **No existing behavior changes**: The feature is purely additive. Accounts that do not opt in are completely unaffected.
+
+## Timeline
+
+### Suggested deployment timeline
+
+This feature will be included in a future framework release, gated behind a feature flag.

--- a/aips/aip-145-multisig-account-timelock.md
+++ b/aips/aip-145-multisig-account-timelock.md
@@ -2,11 +2,11 @@
 aip: 145
 title: Multisig Account Timelock
 author: gregnazario (https://github.com/gregnazario)
-discussions-to: <TODO>
+discussions-to: https://github.com/aptos-foundation/AIPs/pull/667
 Status: Draft
 type: Standard (Framework)
 created: 04/09/2026
-updated:
+updated: 04/10/2026
 requires: AIP-12, AIP-77
 ---
 
@@ -14,7 +14,7 @@ requires: AIP-12, AIP-77
 
 ## Summary
 
-This AIP proposes adding an opt-in timelock mechanism to Aptos multisig accounts. Once a proposed transaction reaches approval quorum, execution is delayed by a configurable period (1 hour to 14 days). A separate, higher signature threshold can be configured to bypass the timelock and allow immediate execution when urgency demands it.
+This AIP proposes adding an opt-in timelock mechanism to Aptos multisig accounts. Once a transaction is proposed, execution is delayed by a configurable period (1 hour to 14 days) from the time of creation. An optional, higher signature threshold can be configured to bypass the timelock and allow immediate execution when urgency demands it.
 
 ## Motivation
 
@@ -24,104 +24,106 @@ Multisig accounts on Aptos are used to manage treasuries, upgrade smart contract
 2. **Social engineering**: An owner could be tricked into approving a malicious transaction. Without a delay, there is no window for other owners to review and reject before execution.
 3. **Operational safety**: Organizations often want a "cool-down" period between approval and execution to allow for final review, compliance checks, or stakeholder notification.
 
-Timelocks are a well-established pattern in blockchain governance (e.g., Compound's Timelock, OpenZeppelin's TimelockController). This proposal brings the same protection to Aptos multisig accounts while preserving the ability to act quickly via a higher approval threshold when genuinely needed.
+Timelocks are a well-established pattern in blockchain governance (e.g., Compound's Timelock, OpenZeppelin's TimelockController). This proposal brings the same protection to Aptos multisig accounts while preserving the ability to act quickly via an optional higher approval threshold when genuinely needed.
 
 ## Impact
 
 - **Existing multisig accounts**: Completely unaffected. The timelock is opt-in; accounts without it configured continue to work exactly as before.
-- **New and upgraded accounts**: Owners can configure a timelock at any time via a multisig transaction. Once configured, all subsequent executions are subject to the delay unless the bypass threshold is met.
-- **Wallet and SDK developers**: Should surface the timelock status (duration and bypass threshold) in their UIs and handle the `ETIMELOCK_NOT_EXPIRED` prologue error gracefully (e.g., showing "Transaction is timelocked until ...").
+- **New and upgraded accounts**: Owners can configure a timelock at any time via a multisig transaction. Once configured, all subsequent executions are subject to the delay unless the optional bypass threshold is met.
+- **Wallet and SDK developers**: Should surface the timelock status (duration and override threshold) in their UIs and handle the `ETIMELOCK_NOT_EXPIRED` prologue error gracefully (e.g., showing "Transaction is timelocked until ...").
 - **Rejections are unaffected**: The timelock applies only to execution, not rejection. If enough owners reject a transaction, it can be removed immediately. The timelock protects against hasty *execution*, not hasty *cancellation*.
 
 ## Specification
 
 ### New Resource
 
-A new resource is stored at the multisig account address alongside the existing `MultisigAccount`:
+A new versioned enum resource is stored at the multisig account address alongside the existing `MultisigAccount`:
 
 ```move
-struct MultisigAccountTimelock has key {
-    /// Seconds that must elapse after quorum before execution is allowed.
-    timelock_secs: u64,
-    /// Number of approvals that bypass the timelock for immediate execution.
-    /// Must be > num_signatures_required and <= num_owners when active.
-    bypass_num_signatures: u64,
-    /// Maps transaction sequence_number -> timestamp when quorum was first reached.
-    approval_timestamps: Table<u64, u64>,
+enum MultisigAccountTimeLock has key, drop {
+    V1 {
+        /// The time lock period in seconds after the creation of the multisig transaction.
+        timelock_period: u64,
+        /// The number of approvals required to bypass the timelock and execute immediately.
+        /// Must be greater than the number of signatures required normally
+        /// and less than or equal to the number of owners.
+        /// None means no bypass is available — the timelock always applies.
+        override_threshold: Option<u64>,
+    }
 }
 ```
 
-A separate resource is used because Move structs that are already stored on-chain cannot have new fields added. This preserves full backward compatibility with the existing `MultisigAccount` and `MultisigTransaction` structs.
+A separate resource is used because Move structs that are already stored on-chain cannot have new fields added. This preserves full backward compatibility with the existing `MultisigAccount` and `MultisigTransaction` structs. A versioned enum (rather than a plain struct) allows future extensions without breaking on-chain state. The `drop` ability allows the resource to be cleanly removed when the timelock is disabled.
 
 ### Configuration
 
-Timelock is configured via a new entry function that can only be invoked as a multisig transaction payload (not `public`, preventing other modules from calling it with a borrowed signer):
+Timelock is configured via two new entry functions that can only be invoked as multisig transaction payloads (not `public`, preventing other modules from calling them with a borrowed signer):
 
 ```move
-entry fun update_timelock(
+/// Configure or update the timelock. To set a timelock without bypass, pass option::none()
+/// for override_threshold.
+entry fun upsert_timelock(
     multisig_account: &signer,
-    new_timelock_secs: u64,
-    new_bypass_num_signatures: u64,
-) acquires MultisigAccount, MultisigAccountTimelock;
+    timelock_period: u64,
+    override_threshold: Option<u64>,
+);
+
+/// Remove the timelock entirely.
+entry fun remove_timelock(multisig_account: &signer);
 ```
 
-**To enable**: `new_timelock_secs > 0` and `new_bypass_num_signatures > num_signatures_required` and `new_bypass_num_signatures <= num_owners`.
+**To enable with bypass**: `timelock_period` in valid range, `override_threshold = option::some(N)` where `N > num_signatures_required` and `N <= num_owners`.
 
-**To disable**: `new_timelock_secs = 0` and `new_bypass_num_signatures = 0`. Disabling itself goes through the active timelock (the transaction must wait out the delay or meet the bypass threshold).
+**To enable without bypass**: `timelock_period` in valid range, `override_threshold = option::none()`. This is useful for cases like a 3-of-3 multisig where there is no higher threshold possible, but a timelock delay is still desired.
 
-**Bounds**: `timelock_secs` must be between `MIN_TIMELOCK_PERIOD` (3,600 seconds / 1 hour) and `MAX_TIMELOCK_PERIOD` (1,209,600 seconds / 14 days).
+**To disable**: Call `remove_timelock`. This itself must go through the active timelock (the transaction must wait out the delay or meet the override threshold) since it is executed as a multisig transaction.
+
+**Bounds**: `timelock_period` must be between `MIN_TIMELOCK_PERIOD` (3,600 seconds / 1 hour) and `MAX_TIMELOCK_PERIOD` (1,209,600 seconds / 14 days). The granularity is at the second level — these bounds simply prevent absurdly short or long timelocks.
 
 ### Execution Logic
 
 A transaction can be executed when:
 
 1. It has reached approval quorum (`num_approvals >= num_signatures_required`), AND either:
-   - **(a)** The number of approvals meets the bypass threshold (`num_approvals >= bypass_num_signatures`), allowing immediate execution, OR
-   - **(b)** Sufficient time has elapsed since quorum was first reached: `now_seconds() >= approval_timestamp + timelock_secs`.
+   - **(a)** An override threshold is configured and the number of approvals meets it (`override_threshold.is_some() && num_approvals >= override_threshold`), allowing immediate execution, OR
+   - **(b)** Sufficient time has elapsed since the transaction was *created*: `now_seconds() - creation_time_secs >= timelock_period`.
 
 If neither condition is met, the transaction prologue rejects with `ETIMELOCK_NOT_EXPIRED`.
 
-### Approval Timestamp Tracking
-
-The `approval_timestamps` table records when each transaction first reached quorum:
-
-| Scenario | Behavior |
-|----------|----------|
-| k-th approval meets quorum | Timestamp recorded with `now_seconds()` |
-| Additional approval after quorum | Timestamp preserved (clock does NOT restart) |
-| Vote change causes quorum loss | Timestamp removed (clock resets) |
-| Quorum restored after loss | New timestamp recorded (clock restarts) |
-| Transaction executed or rejected | Timestamp entry cleaned up |
-| 1-of-N multisig, creator proposes | Timestamp set at creation (auto-approval meets quorum) |
+The timelock is measured from the transaction's `creation_time_secs`, not from when quorum was reached. This simplifies the design — there is no need to track separate approval timestamps — and provides a predictable, auditable delay window.
 
 ### Invariant Enforcement
 
-When the timelock is active, the following invariants are maintained:
+When the timelock is active with an override threshold configured, the following invariants are maintained:
 
-1. `bypass_num_signatures > num_signatures_required`
-2. `bypass_num_signatures <= owners.length()`
+1. `override_threshold > num_signatures_required`
+2. `override_threshold <= owners.length()`
 
-These are enforced both when configuring the timelock (`update_timelock`) and when owners or thresholds change (`update_owner_schema`). Owner removals or threshold increases that would violate these invariants are rejected.
+These are enforced when configuring the timelock (`upsert_timelock`) and when owners or thresholds change (`update_owner_schema`). If an owner removal would cause `override_threshold > num_owners`, the override threshold is automatically reduced to the new owner count. If a threshold increase would cause `override_threshold <= num_signatures_required`, the operation is rejected.
+
+When `override_threshold` is `None`, these invariants are not applicable and no bypass is available.
 
 ### New Error Codes
 
 | Code | Name | Description |
 |------|------|-------------|
-| 2012 | `ETIMELOCK_NOT_EXPIRED` | Prologue error: quorum met but timelock delay has not elapsed |
-| 21 | `EINVALID_TIMELOCK_CONFIG` | `timelock_secs` and `bypass_num_signatures` must both be positive or both zero |
-| 22 | `EINVALID_TIMELOCK_DURATION` | `timelock_secs` outside valid range (1 hour – 14 days) |
-| 23 | `EINVALID_TIMELOCK_BYPASS_THRESHOLD` | `bypass_num_signatures` not in valid range |
+| 2012 | `ETIMELOCK_NOT_EXPIRED` | Prologue error: quorum met but timelock delay has not elapsed and override threshold not met |
+| 21 | `EINVALID_TIMELOCK_DURATION` | `timelock_period` outside valid range (1 hour – 14 days) |
+| 22 | `EINVALID_TIMELOCK_OVERRIDE_THRESHOLD` | `override_threshold` not in valid range relative to `num_signatures_required` and owner count |
 
-### New Event
+### New Events
 
 ```move
 #[event]
 struct TimelockUpdated has drop, store {
     multisig_account: address,
-    old_timelock_secs: u64,
-    new_timelock_secs: u64,
-    old_bypass_num_signatures: u64,
-    new_bypass_num_signatures: u64,
+    timelock_period: u64,
+    override_threshold: Option<u64>,
+}
+
+#[event]
+struct TimelockRemoved has drop, store {
+    multisig_account: address,
 }
 ```
 
@@ -129,43 +131,40 @@ struct TimelockUpdated has drop, store {
 
 ```move
 #[view]
-public fun timelock_secs(multisig_account: address): u64;
+/// Return the timelock duration in seconds, or 0 if no timelock is configured.
+public fun timelock_period(multisig_account: address): u64;
 
 #[view]
-public fun timelock_bypass_num_signatures(multisig_account: address): u64;
+/// Return the override threshold, or option::none() if no timelock or no bypass is configured.
+public fun timelock_override_threshold(multisig_account: address): Option<u64>;
 ```
-
-Both return `0` if no timelock is configured.
 
 ## Implementation Details
 
-All timelock resource access is encapsulated in four non-inline helper functions:
+The timelock check is integrated into the existing `can_execute_with_timelock` function, which is called during both `can_execute` (view) and `validate_multisig_transaction` (prologue). The logic:
 
-1. **`maybe_update_approval_timestamp`** — Called after every vote and transaction creation. Records or removes the quorum timestamp.
-2. **`assert_timelock_expired`** — Called during `validate_multisig_transaction` (prologue). Enforces the delay or bypass.
-3. **`maybe_remove_approval_timestamp`** — Called on transaction execution or rejection. Cleans up the timestamp entry.
-4. **`validate_timelock_invariants`** — Called after owner/threshold changes. Ensures bypass invariants hold.
+1. If no `MultisigAccountTimeLock` resource exists, execution is allowed (backward compatible).
+2. Compute elapsed time: `now_seconds() - pending_transaction.creation_time_secs`.
+3. If override threshold is configured and approvals meet it, allow immediate execution.
+4. Otherwise, require `elapsed >= timelock_period`.
 
-Because these are non-inline functions, their `acquires MultisigAccountTimelock` annotation does **not** propagate to callers. This means no existing function signature or `acquires` clause changes — full ABI compatibility.
+Owner/threshold changes in `update_owner_schema` automatically adjust the override threshold downward if it would exceed the new owner count, and reject changes that would make the override threshold invalid.
 
 ### Changes to Existing Functions
 
 | Function | Change |
 |----------|--------|
-| `vote_transanction` | Calls `maybe_update_approval_timestamp` after recording the vote |
-| `add_transaction` | Calls `maybe_update_approval_timestamp` after creator auto-approval |
-| `validate_multisig_transaction` | Computes effective approvals (including implicit executor vote), calls `assert_timelock_expired` |
-| `transaction_execution_cleanup_common` | Calls `maybe_remove_approval_timestamp` |
-| `execute_rejected_transaction` | Calls `maybe_remove_approval_timestamp` |
-| `update_owner_schema` | Calls `validate_timelock_invariants` at the end |
+| `vote_transanction` | Integrates timelock-aware execution check |
+| `validate_multisig_transaction` | Separates quorum check from timelock check with distinct error codes |
+| `update_owner_schema` | Validates and auto-adjusts timelock override invariants after owner/threshold changes |
 
-**No existing struct definitions change. No existing function signatures change.**
+**No existing struct definitions change.**
 
 ### Behavioral Notes
 
-- **Implicit executor vote**: When the v2 enhancement feature is enabled, the executor's implicit approval counts toward both the regular and bypass thresholds. However, if the implicit vote is what first reaches quorum, no timestamp exists yet — the executor must first explicitly approve (starting the clock), wait out the timelock, then execute. This prevents timelock circumvention via implicit votes.
-- **Enabling on existing accounts**: Pending transactions that already have quorum will NOT have timestamps recorded. A fresh vote (even a redundant re-approval) is needed to start the clock. This is intentional — enabling a timelock is a security hardening step.
-- **Overflow prevention**: Time comparison uses `now_seconds() - approval_time >= timelock_secs` (subtraction-based) rather than `now_seconds() >= approval_time + timelock_secs` to prevent potential overflow.
+- **3-of-3 multisig with timelock**: By passing `override_threshold = option::none()`, a 3-of-3 multisig (where no higher threshold is possible) can still use a timelock. All transactions must wait the full delay — there is no bypass.
+- **Timelock measured from creation**: The delay starts when the transaction is proposed, not when it reaches quorum. This means the timelock may already be partially or fully elapsed by the time enough approvals are gathered, which is the expected behavior — the delay exists to give all owners time to review, and that review period begins at proposal time.
+- **Removing the timelock requires going through the timelock**: Since `remove_timelock` is itself a multisig transaction, it must satisfy the active timelock before it can execute. An attacker who compromises enough keys for regular quorum but not the override threshold cannot immediately disable the timelock.
 
 ## Reference Implementation
 
@@ -173,31 +172,29 @@ https://github.com/gregnazario/aptos-core/tree/multisig-timelock
 
 ## Testing
 
-The implementation includes 13 unit tests covering:
+The implementation includes unit tests covering:
 
 | Test | What it validates |
 |------|-------------------|
-| `test_update_timelock` | Configure timelock, verify via view functions, then disable |
-| `test_update_timelock_invalid_config_should_fail` | Mixed zero/non-zero config rejected |
-| `test_update_timelock_bypass_not_greater_than_threshold_should_fail` | `bypass <= num_signatures_required` rejected |
-| `test_update_timelock_bypass_exceeds_owners_should_fail` | `bypass > num_owners` rejected |
+| `test_upsert_timelock` | Configure timelock, verify via view functions, update, then remove |
+| `test_upsert_timelock_invalid_duration_should_fail` | Duration outside bounds rejected |
+| `test_upsert_timelock_override_not_greater_than_threshold_should_fail` | `override <= num_signatures_required` rejected |
+| `test_upsert_timelock_override_exceeds_owners_should_fail` | `override > num_owners` rejected |
 | `test_execute_before_timelock_expires_should_fail` | Execution blocked during delay period |
 | `test_execute_after_timelock_expires` | Execution succeeds after delay elapses |
-| `test_execute_with_bypass_skips_timelock` | Bypass threshold allows immediate execution |
-| `test_timelock_resets_when_quorum_lost` | Clock resets when quorum is lost and re-established |
-| `test_timelock_set_immediately_for_single_sig` | 1-of-N: timestamp set at creation |
-| `test_remove_owners_invalidates_bypass_should_fail` | Owner removal blocked if it breaks bypass invariant |
-| `test_update_threshold_invalidates_bypass_should_fail` | Threshold increase blocked if it breaks bypass invariant |
+| `test_execute_with_override_skips_timelock` | Override threshold allows immediate execution |
 | `test_no_timelock_executes_normally` | Existing behavior unchanged without timelock |
-| `test_disable_timelock_allows_immediate_execution` | Disabling restores immediate execution |
+| `test_remove_timelock_allows_immediate_execution` | Removing timelock restores immediate execution |
+| `test_remove_owners_adjusts_override` | Owner removal auto-adjusts override threshold downward |
+| `test_update_threshold_invalidates_override_should_fail` | Threshold increase blocked if it breaks override invariant |
 
 These will also be tested on devnet and testnet prior to mainnet deployment.
 
 ## Security Considerations
 
 - **Timelock protects against key compromise**: A configurable delay gives honest owners time to detect unauthorized activity and reject malicious transactions before execution.
-- **Bypass threshold is a deliberate escape hatch**: The higher threshold allows rapid response when genuinely needed (e.g., emergency security patches) while still requiring broader consensus than normal operations.
-- **Disabling the timelock requires going through the timelock**: An attacker who compromises enough keys to meet regular quorum but not the bypass threshold cannot immediately disable the timelock — they must wait out the delay, during which the attack can be detected.
+- **Override threshold is a deliberate escape hatch**: The optional higher threshold allows rapid response when genuinely needed (e.g., emergency security patches) while still requiring broader consensus than normal operations.
+- **Disabling the timelock requires going through the timelock**: An attacker who compromises enough keys to meet regular quorum but not the override threshold cannot immediately disable the timelock — they must wait out the delay, during which the attack can be detected.
 - **Rejections bypass the timelock**: This is intentional. If owners detect a malicious pending transaction, they should be able to remove it immediately without waiting.
 - **No existing behavior changes**: The feature is purely additive. Accounts that do not opt in are completely unaffected.
 


### PR DESCRIPTION
This proposes an opt-in multisig account timelock.  Similar to Aptos governance, where voting must take place for X time, before the propoosal can be completed.